### PR TITLE
Added padding to card content and response to mobile device widths

### DIFF
--- a/coursetracker/templates/coursetracker/course.html
+++ b/coursetracker/templates/coursetracker/course.html
@@ -63,7 +63,7 @@
             <div class="card-header">
                 <h3 class="card-title">Section Professors from 2016-2018</h3>
             </div>
-            <div class="card-body-scroll">
+            <div class="card-body-scroll prof-card">
                 {% for section, profsList in sections_taught.items %}
                 <div class="course-row">
                     <h3 class="grade-info">
@@ -95,7 +95,7 @@
                 <h3 class="card-title">Course Professors</h3>
             </div>
             <div class="card-body-scroll prof-card">
-                {% for name, rating, numratings, sectionstaught in professors_info %}
+                {% for name, rating, numratings in professors_info %}
                 <div class="course-row">
                     <h3 class="grade-info">
                         <span class="info-name">{{ name }}</span>

--- a/homepage/static/homepage/details.css
+++ b/homepage/static/homepage/details.css
@@ -61,7 +61,7 @@ h2.card-title {
 }
 
 .card-body-scroll {
-    height: 400px;
+    height: 300px;
     overflow-y: scroll;
 }
 


### PR DESCRIPTION
Collapses row card orientation to columns if the screen width of similar size to a mobile device. 
Also added padding to the card contents. 

![image](https://user-images.githubusercontent.com/76576876/103722672-5168cf00-4f85-11eb-9fe1-56f9950794c5.png)

![image](https://user-images.githubusercontent.com/76576876/103722724-6e9d9d80-4f85-11eb-95e9-2597dab47b91.png)

Still requires heavy reformatting.

May skew visuals of the homepage if the contents rely on the same classes/wrappers/etc, but could also be the fact that I'm using an ultrawide screen. Don't merge with main!

![image](https://user-images.githubusercontent.com/76576876/103722732-752c1500-4f85-11eb-86d2-a0cd7126fde2.png)