### PR TITLE
trees updated based on adjusted data structure

### DIFF
--- a/coursetracker/templates/coursetracker/course.html
+++ b/coursetracker/templates/coursetracker/course.html
@@ -160,7 +160,7 @@
             <p><b>Corequisites:</b> {{ course.corequisites_description }}</p>
         </div>
         <div class="card-body-scroll2">
-            {% include 'coursetracker/tree.html' %}
+            {% include 'coursetracker/root.html' %}
         </div>
     </div>
 

--- a/coursetracker/templates/coursetracker/root.html
+++ b/coursetracker/templates/coursetracker/root.html
@@ -1,0 +1,17 @@
+{% load static %}
+<script src="{% static '/homepage/tree.js' %}" type="text/javascript"></script>
+<div class="tree" id="tree">
+    <ul>
+        <li>
+            <a href="{{ course.course_name }}" tree-node> {{ course.course_name }} </a>
+            {% if preq.items|length %} 
+            <div class="button" button>▼</div>
+            <div class="dropdown-content" dropdown>
+                <ul>
+                    {% include 'coursetracker/tree.html' %}
+                </ul>
+            </div>
+            {% endif %}
+        </li>
+    </ul>
+</div>

--- a/coursetracker/templates/coursetracker/tree.html
+++ b/coursetracker/templates/coursetracker/tree.html
@@ -1,6 +1,6 @@
 {% load static %}
 <script src="{% static '/homepage/tree.js' %}" type="text/javascript"></script>
-<div class="tree">
+<div class="tree" id="tree">
   <ul>
     {% for key, value in preq.items %}
       <li>

--- a/static/homepage/details.css
+++ b/static/homepage/details.css
@@ -103,11 +103,17 @@ h2.card-title {
     height: 375px;
     overflow-y: scroll;
     overflow-x: scroll;
+    justify-content: center;
 }
 
 .card-body-scroll2 {
-    overflow-y: scroll;
+    height: 500px;
+    width: 1200px;
     overflow-x: scroll;
+    overflow-y: scroll;
+    justify-content: center;
+    margin: auto;
+    white-space: nowrap;
 }
 
 /* Padding adjustments for card content */

--- a/static/homepage/main.css
+++ b/static/homepage/main.css
@@ -7,6 +7,7 @@
     padding-bottom: 2em;
     padding-top: 6em;
     width: 100%;
+    overflow: scroll;
 }
 
 #prereq, #dependent, #rmp {

--- a/static/homepage/tree.css
+++ b/static/homepage/tree.css
@@ -16,7 +16,7 @@
 }
 
 .tree li {
-  float: left;
+
   text-align: center;
   list-style-type: none;
   position: relative;
@@ -25,6 +25,10 @@
   transition: all 0.5s;
   -webkit-transition: all 0.5s;
   -moz-transition: all 0.5s;
+
+  display: inline-block;
+  white-space: nowrap;
+  vertical-align: top;
 }
 
 /*We will use ::before and ::after to draw the connectors*/


### PR DESCRIPTION
Changes:
- Larger prerequisite trees now overflow horizontally/vertically and are scrollable
      - Adjustments to main.css, details.css and tree.css for scrolling and tree dimensions
- Created root.html file to account for "root of the tree" (to include course that is searched for at the top due to adjusted data structure)

Images:

![image](https://user-images.githubusercontent.com/64457658/127279085-a8630f85-c06a-4bc2-a209-886837cc2ba7.png)

(MATH 221 example overflows length-wise, users can scroll horizontally.)

Future considerations:
- "Categorizing" pre-requisites ("one of x, y, z", "x and y", etc.), though probably fairly challenging
- Filtering (hiding) duplicate pre-requisites --> has pros and cons
- Styling



