### PR TITLE
Create all_courses_api and course_api views

### DIFF
--- a/app/coursetracker/serializers.py
+++ b/app/coursetracker/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+from coursetracker.models import Course
+
+
+class CourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Course
+        fields = ['course_name', 'sub_name', 'course_link', 'average', 'five_year_average', 'standard_deviation',
+                  'number_of_credits', 'lowest_average', 'highest_average', 'profile_link', 'distribution',
+                  'distribution_term', 'distribution_link', 'sections_teaching_team', 'professor_ratings',
+                  'course_description', 'prerequisites_description', 'corequisites_description', 'prerequisite_tree']

--- a/app/coursetracker/urls.py
+++ b/app/coursetracker/urls.py
@@ -6,5 +6,7 @@ app_name = 'coursetracker'
 
 urlpatterns = [
     path('search', views.search, name="search"),
-    path('view/<str:course_name>', views.course, name="course")
+    path('view/<str:course_name>', views.course, name="course"),
+    path('all_courses_api', views.all_courses_api),
+    path('course_api/<str:course_name>', views.course_api)
 ]

--- a/app/coursetracker/views.py
+++ b/app/coursetracker/views.py
@@ -1,6 +1,8 @@
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 
 from .models import Course
+from .serializers import CourseSerializer
 
 
 def search(request):
@@ -28,3 +30,21 @@ def course(request, course_name):
         return render(request, 'coursetracker/404.html')
 
     return render(request, 'coursetracker/course.html', {'course': c})
+
+
+def all_courses_api(request):
+    courses = Course.objects.all()
+    serializer = CourseSerializer(courses, many=True)
+    return JsonResponse(serializer.data, safe=False)
+
+
+def course_api(request, course_name):
+    try:
+        c = Course.objects.get(course_name__exact=course_name)
+        print(f"*{course_name} found in database")
+    except Course.DoesNotExist:
+        print(f"*Course {course_name} does not exist")
+        return render(request, 'coursetracker/404.html')
+
+    serializer = CourseSerializer(c)
+    return JsonResponse(serializer.data, json_dumps_params={'indent': 2})

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ certifi==2021.5.30
 charset-normalizer==2.0.3
 Django==3.1.13
 django-environ==0.4.5
+djangorestframework==3.12.4
 idna==3.2
 psycopg2==2.9.1
 pytz==2021.1


### PR DESCRIPTION
Very basic REST API
- `course/all_courses_api`: all courses
- `course/course_api/<course_name>`: specific course, with pretty printing
    - i.e., `course/all_courses_api/MATH%20101`
     ![image](https://user-images.githubusercontent.com/65756895/129820539-70094871-b6ce-465b-99d8-fd908c06b557.png)
